### PR TITLE
chore: redirect actions to freshaengineering + pin to SHA

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-05-25T15:31:45Z
+generated_at: 2026-06-11T15:41:05Z
 internal: []
 trusted:
   - action: actions/checkout
@@ -15,9 +15,9 @@ trusted:
           - jobs.release.steps.[0].uses
   - action: actions/stale
     refs:
-      - v4
+      - a20b814fb01b71def3bd6f56e7494d667ddf28da
     occurrences:
-      v4:
+      a20b814fb01b71def3bd6f56e7494d667ddf28da:
         .github/workflows/stale-actions.yaml:
           - jobs.stale.steps.[0].uses
 external:

--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -14,7 +14,7 @@ jobs:
       - runner=2cpu-linux-x64
       - "run-id=${{ github.run_id }}"
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Staling issues and PR's


### PR DESCRIPTION
## Summary
- Redirects all `surgeventures/platform-tribe-actions` references to `freshaengineering/platform-tribe-actions`
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following 5 commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA